### PR TITLE
Upgrade checkout action from v4 to v5

### DIFF
--- a/workflow-templates/handle-pr-approval.yml
+++ b/workflow-templates/handle-pr-approval.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.review.state == 'approved'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Add random meme
         uses: ChainReaction-LTD/approved-pr-random-meme@v1


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow by upgrading the checkout action to the latest major version. This helps ensure improved performance and security.

* Upgraded the `actions/checkout` action from version 4 to version 5 in the `workflow-templates/handle-pr-approval.yml` workflow.