### PR TITLE
Modify Dependabot PR handling merge and squash by adding GitHub CLI i…

### DIFF
--- a/workflow-templates/handle-pr-approval.yml
+++ b/workflow-templates/handle-pr-approval.yml
@@ -21,14 +21,47 @@ jobs:
         with:
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
-      - name: Dependabot squash and merge
+      - name: Check for GitHub CLI
+        run: |
+          if ! command -v gh &> /dev/null; then
+            echo "[INFO] GitHub CLI not found. Installing..."
+            sudo apt-get update
+            sudo apt-get install -y gh
+            echo "[INFO] GitHub CLI installed successfully"
+          else
+            echo "[INFO] GitHub CLI is already installed"
+          fi
+
+      - name: Github's auto squash merge for Dependabot PRs
         if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
         shell: bash
         run: |
-          curl -fSsL \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -d "{\"body\": \"@dependabot squash and merge\"}" \
-            "${{ github.api_url }}/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+          # Initialize status
+          status="success"
+
+          # Function to post a comment on the PR
+          post_comment() {
+            local reason="$1"
+            # Comment about failure
+            local COMMENT_BODY="{\"body\": \"@ChainReaction-LTD/devops squash and merge failed, $reason\"}"
+            curl -fSsL \
+              -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -d "$COMMENT_BODY" \
+              "${{ github.api_url }}/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+          }
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          echo "[INFO] Enabling auto-merge (squash) for Dependabot PR #$PR_NUMBER via gh CLI"
+          export GH_TOKEN="${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          if ! gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --squash --auto; then
+            echo "[ERROR] gh CLI auto-merge request failed"
+            status="failed"
+            reason="gh pr merge --auto failed"
+          fi
+
+          # if final status is failed, post a comment
+          if [[ "$status" == "failed" ]]; then
+            post_comment "$reason"
+          fi


### PR DESCRIPTION
This pull request updates the `handle-pr-approval.yml` workflow to improve the automation and reliability of merging Dependabot pull requests. The main changes ensure that the GitHub CLI (`gh`) is available in the workflow environment and replace the previous merge step with a more robust, automated approach using the `gh` CLI, including error handling and notification.

**Enhancements to Dependabot PR auto-merge:**

* Added a step to check for and install the GitHub CLI (`gh`) if it is not already present, ensuring the workflow can use CLI commands reliably.
* Replaced the previous squash and merge step with a shell script that uses the `gh pr merge --squash --auto` command for Dependabot PRs, providing better automation and feedback.
* Implemented error handling: if the merge fails, the workflow now posts a comment tagging the DevOps team and indicating the failure reason directly on the PR.