### PR TITLE
DO-3251 Upgrade checkout to v6 and simplify Dependabot auto-merge error handling

### DIFF
--- a/workflow-templates/handle-pr-approval.yml
+++ b/workflow-templates/handle-pr-approval.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.review.state == 'approved'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Add random meme
         uses: ChainReaction-LTD/approved-pr-random-meme@v1
@@ -35,33 +35,13 @@ jobs:
       - name: Github's auto squash merge for Dependabot PRs
         if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
-          # Initialize status
-          status="success"
-
-          # Function to post a comment on the PR
-          post_comment() {
-            local reason="$1"
-            # Comment about failure
-            local COMMENT_BODY="{\"body\": \"@ChainReaction-LTD/devops squash and merge failed, $reason\"}"
-            curl -fSsL \
-              -X POST \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              -d "$COMMENT_BODY" \
-              "${{ github.api_url }}/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
-          }
           PR_NUMBER="${{ github.event.pull_request.number }}"
           echo "[INFO] Enabling auto-merge (squash) for Dependabot PR #$PR_NUMBER via gh CLI"
-          export GH_TOKEN="${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           if ! gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --squash --auto; then
             echo "[ERROR] gh CLI auto-merge request failed"
-            status="failed"
-            reason="gh pr merge --auto failed"
-          fi
-
-          # if final status is failed, post a comment
-          if [[ "$status" == "failed" ]]; then
-            post_comment "$reason"
+            gh issue comment "$PR_NUMBER" --repo "${{ github.repository }}" \
+              --body "@ChainReaction-LTD/devops squash and merge failed, gh pr merge --auto failed"
           fi


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v5 to v6
- Replace curl-based PR comment with `gh issue comment`
- Move `GH_TOKEN` to `env:` block instead of inline export
- Remove unused `status` variable and simplify the failure path

## Jira
DO-3251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DO-3251]: https://chainreaction.atlassian.net/browse/DO-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ